### PR TITLE
Fix for 32-bit architectures

### DIFF
--- a/timezones.go
+++ b/timezones.go
@@ -94,8 +94,9 @@ func buildTZData(template *Template) ([]byte, error) {
 	if len(template.Zones) == 0 && template.Extend == "" {
 		return nil, fmt.Errorf("either zones or extend string need to be present")
 	}
-	if len(template.Changes) > math.MaxUint32 {
-		return nil, fmt.Errorf("too many changes (%d), max is %d", len(template.Changes), math.MaxUint32)
+	nchanges := int64(len(template.Changes))
+	if nchanges > math.MaxUint32 {
+		return nil, fmt.Errorf("too many changes (%d), max is %v", nchanges, int64(math.MaxUint32))
 	}
 
 	size := headerSize + // v1 header + empty v1 data block


### PR DESCRIPTION
On 32-bit platforms, ARM in my case but this is not specific to arm, with go1.23.3, `go build` fails with:

```
# github.com/martin-sucha/timezones
vendor/github.com/martin-sucha/timezones/timezones.go:97:29: math.MaxUint32 (untyped int constant 4294967295) overflows int
vendor/github.com/martin-sucha/timezones/timezones.go:98:85: cannot use math.MaxUint32 (untyped int constant 4294967295) as int value in argument to fmt.Errorf (overflows)
```
This PR simply casts to int64 the integers variables involved with 4294967295 comparisons

And the library works on ARM 32-bit